### PR TITLE
upgrade jekyll-asciidoc gem to 2.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 3.1.0'
-gem 'asciidoctor', '~> 1.5.0'
 gem 'coderay', '~> 1.1.0'
 gem 'rake-jekyll', '~> 1.1.0'
 
 group :jekyll_plugins do
-  gem "jekyll-asciidoc", '~> 1.0.0'
+  gem 'jekyll-asciidoc', '~> 2.0.1'
 end

--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,6 +1,6 @@
-The MIT License
-
-Copyright (C) 2015 John Ericksen
+.The MIT License
+....
+Copyright (C) 2015-2016 John Ericksen and the Asciidoctor Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+....

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = Jekyll AsciiDoc Quickstart
 :toc:
 
-The Jekyll AsciiDoc Quickstart project is a leg-up in starting your own website hosted on Github with content based in AsciiDoc.  This project combines the power of AsciiDoc with a beautiful CSS framework and blog-ready template on top of Github's existing publishing infrastructure.
+The Jekyll AsciiDoc Quickstart project is a leg-up in starting your own website hosted on GitHub with content based in AsciiDoc.  This project combines the power of AsciiDoc with a beautiful CSS framework and blog-ready template on top of GitHub's existing publishing infrastructure.
 
 == Directions
 
@@ -25,7 +25,7 @@ Run the following command to install the Travis gem:
 
 === {counter:directions}. Fork this Repository and Clone
 
-To create your own copy of this repository, start by clicking the fork button in the upper right corner of the Github page.
+To create your own copy of this repository, start by clicking the fork button in the upper right corner of the GitHub page.
 
 Next, open a command line window and make a clone of your new repository:
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,16 @@
-# jekyll configuration
-
-title: "Jekyll-asciidoc-quickstart"
-
+title: Jekyll AsciiDoc Quickstart
+description: The Jekyll AsciiDoc Quickstart project is a leg-up in starting your own website hosted on GitHub with content based in AsciiDoc.
+exclude:
+  - LICENSE.adoc
+  - README.adoc
+  - Gemfile
+  - Gemfile.lock
+  - Rakefile
+asciidoc: {}
 asciidoctor:
+  base_dir: :docdir
+  safe: unsafe
   attributes:
     - idseparator=_
     - source-highlighter=coderay
     - icons=font
-
-# end of configuration

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,21 +3,16 @@
 <html class="lt-ie10" lang="en"> <![endif]-->
 <html class="no-js" lang="en" data-useragent="Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)">
 <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{page.title}}</title>
-
-
-    <meta name="description"
-          content="Update what your Blog is about in this section"/>
-
-    <meta name="author" content="Your name goes here"/>
-    <meta name="copyright" content="Maybe consider a Creative Commons license"/>
-
-    <link rel="stylesheet" href="{{page.root}}css/foundation.css"/>
-    <link rel="stylesheet" href="{{page.root}}css/font-awesome.css"/>
-    <link rel="stylesheet" href="{{page.root}}css/coderay.css"/>
-    <link rel="stylesheet" href="{{page.root}}css/asciidoctor.css"/>
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <meta name="author" content="Your name goes here">
+    <meta name="copyright" content="Maybe consider a Creative Commons license">
+    <link rel="stylesheet" href="{{page.root}}css/foundation.css">
+    <link rel="stylesheet" href="{{page.root}}css/font-awesome.css">
+    <link rel="stylesheet" href="{{page.root}}css/coderay.css">
+    <link rel="stylesheet" href="{{page.root}}css/asciidoctor.css">
     <script src="{{page.root}}js/vendor/modernizr.js"></script>
     <script src="{{page.root}}js/toc.js"></script>
 </head>
@@ -31,9 +26,7 @@
         <!-- Title Area -->
         <li class="name">
             <h1>
-                <a href="{{page.root}}">
-                    {{page.title}}
-                </a>
+                <a href="{{page.root}}">{{site.title}}</a>
             </h1>
         </li>
         <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a></li>
@@ -62,7 +55,7 @@
         <h4>Posts</h4>
         <ul id="posts" class="posts nav">
             {% for post in site.posts limit: 5 %}
-            <li><a href=".{{ post.url }}">{{ post.shortTitle }}</a></li>
+            <li><a href=".{{ post.url }}">{{ post.navtitle }}</a></li>
             {% endfor %}
         </ul>
 
@@ -85,7 +78,7 @@
 
 <footer class="row">
     <div class="large-12 columns">
-        <hr/>
+        <hr>
         <div class="row">
             <div class="large-12 columns">
                 <p>Footer</p>
@@ -97,15 +90,9 @@
 <script src="{{page.root}}js/vendor/jquery.js"></script>
 <script src="{{page.root}}js/foundation.min.js"></script>
 <script>
-    $(document).foundation();
-</script>
-<script src="{{page.root}}js/vendor/jquery.js"></script>
-<script src="{{page.root}}js/foundation/foundation.js"></script>
-<script>
-    $(document).foundation();
-
-    var doc = document.documentElement;
-    doc.setAttribute('data-useragent', navigator.userAgent);
+$(document).foundation();
+var doc = document.documentElement;
+doc.setAttribute('data-useragent', navigator.userAgent);
 </script>
 </body>
 </html>

--- a/_posts/2015-01-01-first-entry.adoc
+++ b/_posts/2015-01-01-first-entry.adoc
@@ -1,15 +1,10 @@
----
-layout: default
-title: Jekyll-Asciidoc Quickstart
-shortTitle: Entry short title
-documentationExpanded: false
-comments: true
-postsExpanded: true
-excerpt: excerpt
-root: ../../../
----
+= First Entry
+:showtitle:
+:page-navtitle: First Entry
+:page-excerpt: Excerpt goes here.
+:page-root: ../../../
 
-=== Example entry
+== Example entry
 
 Lorem ipsum dolor sit amet, et elitr docendi officiis vix. An has impedit concludaturque, an vim dicam feugiat nominavi. Veniam oblique menandri sea ea, agam novum appareat in his. Constituto posidonium te his. Pri quot iudico ex, noster apeirian concludaturque mel cu.
 

--- a/index.adoc
+++ b/index.adoc
@@ -1,47 +1,41 @@
----
-layout: default
-title: Jekyll-Asciidoc Quickstart
-description: A forkable blog-ready Jekyll site using Asciidoc
-documentationExpanded: false
-postsExpanded: false
----
-
 = Congratulations!
+:showtitle:
+:page-title: Jekyll AsciiDoc Quickstart
+:page-description: A forkable blog-ready Jekyll site using AsciiDoc
 
-You've successfully set up and deployed an Jekyll website powered by Asciidoc using the https://github.com/asciidoctor/jekyll-asciidoc-quickstart[*Asciidoc-Jekyll-Quickstart*] project.  If everything is in order then changes to the Asciidoc content will be automatically published to your `gh_pages` branch and hosted via Jekyll and Github.
+You've successfully set up and deployed an Jekyll website powered by AsciiDoc using the https://github.com/asciidoctor/jekyll-asciidoc-quickstart[*Jekyll AsciiDoc Quickstart*] project. If everything is in order then changes to the AsciiDoc content will be automatically published to your `gh_pages` branch and hosted via Jekyll and Github.
 
 == What do I do now?
 
-Now that you've set up your website to run with Asciidoc you have a ton of options available to you.
+Now that you've set up your website to run with AsciiDoc, you have a ton of options available to you.
 
-==== Edit content
-Editing content is very simple.  The easiest way to update your blog is to clone your repository, fire up your favorite text editor and run the content locally.  To do this run the `jekyll serve` command and open a web browser to http://localhost:4000.  Jekyll will automatically process and host changes to the content.
+=== Edit content
 
-You may also edit your content directly on Github.  To do this, navigate the browser the file you wish to edit, click the pensil (edit) button in the upper right hand corner of the view and make your changes.  When you're finished, commit your changes.  This will trigger Travis to generate and publish a new website including your changes.
+Editing content is very simple. The easiest way to update your blog is to clone your repository, fire up your favorite text editor and run the content locally. To do this run the `jekyll serve` command and open a web browser to http://localhost:4000. Jekyll will automatically process and host changes to the content.
 
-For blog posts, Jekyll will recognize files under the `_post` directory, parse the name and place it in the list of posts.  These will show up under the `site.posts` variable.
+You may also edit your content directly on Github. To do this, navigate the browser the file you wish to edit, click the pensil (edit) button in the upper right hand corner of the view and make your changes. When you're finished, commit your changes. This will trigger Travis to generate and publish a new website including your changes.
+
+For blog posts, Jekyll will recognize files under the `_post` directory, parse the name and place it in the list of posts. These will show up under the `site.posts` variable.
 
 To display a list of posts, use Jekyll syntax similar to the following:
 
 [source, html]
---
-{% raw %}
+----
 {% for post in site.posts limit: 5 %}
-    <a href=".{{ post.url }}">{{ post.shortTitle }}</a>
+<a href=".{{ post.url }}">{{ post.navtitle }}</a>
 {% endfor %}
-{% endraw %}
---
+----
 
+=== Update Look and feel
 
-==== Update Look and feel
-The layout provided with the https://github.com/asciidoctor/jekyll-asciidoc-quickstart[Jekyll-Asciidoc Quickstart] project is based on http://foundation.zurb.com[Foundation], a responsive design css framework.  You're free to update the layout by editing the `_layouts/default.html` file and css under the `css` directory.
+The layout provided with the https://github.com/asciidoctor/jekyll-asciidoc-quickstart[Jekyll AsciiDoc Quickstart] project is based on http://foundation.zurb.com[Foundation], a responsive design css framework. You're free to update the layout by editing the `_layouts/default.html` file and css under the `css` directory.
 
-This blog layout is based on the http://foundation.zurb.com/templates/blog.html[Blog template].
+//This blog layout is based on the http://foundation.zurb.com/templates-previews-sites-f6/blog.html[Blog template].
 
-==== Reference documentation
-The following links will help with detailed explanations on Jekyll and Asciidoc.
+=== Reference documentation
 
-http://jekyllrb.com[Jekyll]
-http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[Asciidoc Quick Reference]
-http://asciidoctor.org[Asciidoctor]
+The following links will help with detailed explanations on Jekyll and AsciiDoc.
 
+* http://jekyllrb.com[Jekyll]
+* http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[AsciiDoc Quick Reference]
+* http://asciidoctor.org[Asciidoctor]


### PR DESCRIPTION
- upgrade jekyll-asciidoc gem to 2.0.1
- allow jekyll-asciidoc to pull in asciidoctor gem
- define page variables as AsciiDoc page attributes instead of front matter
- add list of excludes that shouldn't be copied to site
- add site description to config file
- pull page description from page or site
- add empty asciidoc config to config file
- define base_dir and unsafe
- capitalize GitHub properly (GitHub instead of Github)
- capitalize AsciiDoc property (AsciiDoc instead of Asciidoc)
- don't load JavaScript twice
- fix heading levels in sample pages
- don't wrap source listing in liquid raw tags
- minor content fixes
- slightly cleanup HTML template; don't close short tags
