### PR TITLE
fix link to posts in the sidebar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,7 +55,7 @@
         <h4>Posts</h4>
         <ul id="posts" class="posts nav">
             {% for post in site.posts limit: 5 %}
-            <li><a href=".{{ post.url }}">{{ post.navtitle }}</a></li>
+            <li><a href="{{ post.url }}">{{ post.navtitle }}</a></li>
             {% endfor %}
         </ul>
 


### PR DESCRIPTION
.{{ post.url }} prepends the current path to {{ post.url }}, the one
cannot nagivate to other posts from the post with these links.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>