### PR TITLE
upgrade actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
       env:
         JEKYLL_ENV: production
     - name: Upload Artifacts
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
When I used the template I got an error during build
```
Download action repository 'actions/checkout@v4' (SHA:11bd71901bbe5b1630ceea73d27597364c9af683)
Download action repository 'actions/configure-pages@v3' (SHA:b8130d9ab958b325bbde9786d62f2c97a9885a0e)
Download action repository 'ruby/setup-ruby@v1' (SHA:277ba2a127aba66d45bad0fa2dc56f80dbfedffa)
Download action repository 'actions/upload-pages-artifact@v1' (SHA:84bb4cd4b733d5c320c9c9cfbc354937524f4d64)
Download action repository 'actions/deploy-pages@v2' (SHA:de14547edc9944350dc0481aa5b7afb08e75f254)
Getting action download info
Error: Missing download info for actions/upload-artifact@v3
```

This seems to be connected to https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

I have no idea what i am doing but I changed the versions of these action like mentioned here https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/

That fixed the issue. I just wanted to let this flow back in here. Thanks for the template!